### PR TITLE
Issue-8: Added documentation for wrapped api calls

### DIFF
--- a/spacex_py/capsules.py
+++ b/spacex_py/capsules.py
@@ -1,7 +1,38 @@
 from ._helpers._api import _get
 
 def get_capsules(method=""):
+    """Gets all capsules
+
+        Gets capsules from the API
+
+    Parameters
+    ----------
+        method : str (optional)
+            the method used for the request
+
+    Returns
+    -------
+        list
+            a list of capsules
+    """
     return _get("capsules", method)
 
 def get_capsule_parts(method="", **query):
+    """Gets all capsule parts based on query strings
+
+        Gets all capsule parts based on query strings
+        from the API
+
+    Parameters
+    ----------
+        method : str (optional)
+            the method used for the request
+        query : keyword args
+            keyword args based on the API query strings
+
+    Returns
+    -------
+        list
+            a list of the capsule parts
+    """
     return _get("parts/caps", method, query)

--- a/spacex_py/cores.py
+++ b/spacex_py/cores.py
@@ -1,4 +1,21 @@
 from ._helpers._api import _get
 
 def get_cores(method="", **query):
+    """Gets all core parts based on query strings
+
+        Gets all core parts based on query strings
+        from the API
+
+    Parameters
+    ----------
+        method : str (optional)
+            the method used for the request
+        query : keyword args
+            keyword args based on the API query strings
+
+    Returns
+    -------
+        list
+            a list of the core parts
+    """
     return _get("parts/cores", method, query)

--- a/spacex_py/info.py
+++ b/spacex_py/info.py
@@ -1,10 +1,40 @@
 from ._helpers._api import _get
 
 def get_company_info():
+    """Gets information on SpaceX
+
+        Gets information on Space Exploration Technologies Corp
+        from the API
+
+    Returns
+    -------
+        dict
+            a dict of the company information
+    """
     return _get("info")
 
 def get_company_history_info():
+    """Gets company history and milestones
+
+        Gets company history and milestones from
+        the API
+
+    Returns
+    -------
+        list
+            a list of the company's historical events and milestones
+    """
     return _get("info/history")
 
 def get_roadster_info():
+    """Gets information and orbital data for Starman Roadster
+
+        Gets information and orbital data for Starman Roadster
+        from the API (Updated every 10 minutes)
+
+    Returns
+    -------
+        dict
+            a dict of the Starman Roadster's information and orbital data
+    """
     return _get("info/roadster")

--- a/spacex_py/launches.py
+++ b/spacex_py/launches.py
@@ -11,7 +11,7 @@ def get_launches(method="", **query):
         method : str (optional)
             the method used for the request
         query : keyword args
-            keyword args based on the API query stings
+            keyword args based on the API query strings
 
     Returns
     -------

--- a/spacex_py/launchpads.py
+++ b/spacex_py/launchpads.py
@@ -1,4 +1,19 @@
 from ._helpers._api import _get
 
 def get_launchpads(method=""):
+    """Gets information related to launchpads used for SpaceX flights
+
+        Gets information related to launchpads
+        from the API
+
+    Parameters
+    ----------
+        method : str (optional)
+            the method used for the request
+
+    Returns
+    -------
+        list
+            a list of the launchpads
+    """
     return _get("launchpads", method)

--- a/spacex_py/rockets.py
+++ b/spacex_py/rockets.py
@@ -1,4 +1,19 @@
 from ._helpers._api import _get
 
 def get_rockets(method=""):
+    """Gets information related to SpaceX rockets
+
+        Gets information related to rockets from
+        the API
+
+    Parameters
+    ----------
+        method : str (optional)
+            the method used for the request
+
+    Returns
+    -------
+        list
+            a list of the rockets
+    """
     return _get("rockets", method)


### PR DESCRIPTION
Added documentation for capsules, cores, info, launchpads and rockets. Fixed a typo in launches.

P.S.: I am not sure how the process is for review, so please let me know if you find anything wrong or need any changed (even if it is really really tiny). :-) I created a branch on my local repo and am creating a PR for that.

- Also, while reviewing the code, I found the name "method" to be confusing to be used as an argument for endpoint group or maybe for using it to provide specific id of an object since 'method' in context of ReST API is usually HTTP methods. Is there a specific reason why it is used?

- Also,  the method get_capsule_parts() should be split into two methods:
    - One to get all parts or for query params which returns a list
    - One for getting part by serial number which returns a dict. Using 'method' to pass in serial number is confusing. 
Since the single method returns either a list or dict depending on what is asked, it will be beneficial to have two methods to separate the two workflows. Right now, I am not sure whether I should be including the dict part in the docstring so let me know if I need to change that. Same for get_cores(), get_launchpads(), get_rockets().

Let me know if you need issues created for the above concerns. Thanks! :-)
